### PR TITLE
Students can only drop themselves

### DIFF
--- a/etc/krakend.json
+++ b/etc/krakend.json
@@ -102,12 +102,18 @@
       }
     },
     {
-      "endpoint": "/api/students/{student_id}/classes/{class_id}/drop/",
-      "method": "PUT",
+      "endpoint": "/api/students/classes/{class_id}",
+      "method": "DELETE",
+      "input_headers": ["x-cwid"],
       "backend": [
         {
-          "url_pattern": "/students/{student_id}/classes/{class_id}/drop/",
-          "host": ["http://localhost:5000", "http://localhost:5001", "http://localhost:5002"]
+          "url_pattern": "/students/classes/{class_id}",
+          "host": ["http://localhost:5000", "http://localhost:5001", "http://localhost:5002"],
+          "extra_config": {
+            "backend/http": {
+              "return_error_details": "backend_b"
+            }
+          }
         }
       ],
       "extra_config": {
@@ -117,7 +123,10 @@
           "roles": ["registrar","student","professor"],
           "jwk_local_path": "./enrollment_service/public.json",
           "disable_jwk_security": true,
-          "operation_debug": true
+          "operation_debug": true,
+          "propagate_claims": [
+            ["jti", "x-cwid"]
+          ]
         }
       }
     },


### PR DESCRIPTION
# What?
Added a restriction "Students can only drop themselves".

# Why?
Students are not allowed to drop class on behalf of another student.

# Changes?
- In `./etc/krakend.json`:
  - Changed the endpoint to `/api/students/classes/{class_id}`
  - Changed the method to `DELETE`
  - Forward  the JWT used id to the backend service
- In `./enrollment_service/routes.py`:
  - Changed the endpoint to `/students/classes/{class_id}`
  - Changed the function parameters.
  - Fixed a bug when checking if a student is not enrolled in the class or not